### PR TITLE
Fix boot parameter in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jail { 'myjail1':
   ip4_addr => 'em0|10.0.0.10/24',
   ip6_addr => 'em0|fc00::10/64',
   hostname => 'myjail1.example.com',
-  boot     => 'yes'
+  boot     => 'on'
 }
 ```
 


### PR DESCRIPTION
The "boot" parameter must be "on" or "off", not "yes".

Without this change, we get the following error:

Error: Parameter boot failed on Jail[myjail1]: Invalid value "yes". Valid values are on, off.