### PR TITLE
Update fixture and tests for non-iocage jail

### DIFF
--- a/lib/puppet/provider/jail/iocage.rb
+++ b/lib/puppet/provider/jail/iocage.rb
@@ -17,6 +17,10 @@ Puppet::Type.type(:jail).provide(:iocage) do
     output.each {|j|
       jail_data = {}
       values = j.split()
+
+      iocage_jail_list_regex = /^(-|[1-9]+)\s+([[:xdigit:]]{8}-([[:xdigit:]]{4}-){3})[[:xdigit:]]{12}\s+(on|off)\s+(up|down)\s+\w+$/
+      next if iocage_jail_list_regex.match(j) == nil
+
       values.each_index {|i|
         jail_data[fields[i]] = values[i]
       }

--- a/spec/fixtures/iocage_list
+++ b/spec/fixtures/iocage_list
@@ -1,3 +1,24 @@
 JID   UUID                                  BOOT  STATE  TAG
-1     b604d70f-220f-11e5-ad5f-0025905cf7cd  off   up     mon1
--     fdfad85f-220c-11e5-ad5f-0025905cf7cd  off   down   fbsd10.1
+-     018e776d-4315-11e5-94bc-0025905cf7cc  off   down   auth4
+-     14b47568-448e-11e5-94bc-0025905cf7cc  off   down   graphite2
+1     19e2885e-448e-11e5-94bc-0025905cf7cc  on    up     git2
+2     64a7af2c-4909-11e5-9073-0025905cf7cc  on    up     pm3
+-     c3936d1d-46f5-11e5-9073-0025905cf7cc  off   down   ns1
+333   ca29dc76-46f6-11e5-9073-0025905cf7cc  on    up     pdb2
+-     e2f5f461-4314-11e5-94bc-0025905cf7cc  off   down   mon1
+--- non iocage jails currently active ---
+JID   PATH                                  IP4              HOSTNAME 
+4     /usr/local/poudriere/data/.m/10amd64  127.0.0.1        10amd64-default
+5     /usr/local/poudriere/data/.m/10amd64  -                10amd64-default
+6     /usr/local/poudriere/data/.m/10amd64  127.0.0.1        10amd64-default-job-05
+7     /usr/local/poudriere/data/.m/10amd64  -                10amd64-default-job-05
+8     /usr/local/poudriere/data/.m/10amd64  127.0.0.1        10amd64-default-job-02
+9     /usr/local/poudriere/data/.m/10amd64  127.0.0.1        10amd64-default-job-06
+10    /usr/local/poudriere/data/.m/10amd64  -                10amd64-default-job-02
+11    /usr/local/poudriere/data/.m/10amd64  -                10amd64-default-job-06
+12    /usr/local/poudriere/data/.m/10amd64  127.0.0.1        10amd64-default-job-04
+13    /usr/local/poudriere/data/.m/10amd64  -                10amd64-default-job-04
+14    /usr/local/poudriere/data/.m/10amd64  127.0.0.1        10amd64-default-job-01
+15    /usr/local/poudriere/data/.m/10amd64  -                10amd64-default-job-01
+16    /usr/local/poudriere/data/.m/10amd64  127.0.0.1        10amd64-default-job-03
+17    /usr/local/poudriere/data/.m/10amd64  -                10amd64-default-job-03

--- a/spec/unit/puppet/provider/iocage_spec.rb
+++ b/spec/unit/puppet/provider/iocage_spec.rb
@@ -11,7 +11,7 @@ describe provider_class do
       fixture = File.read('spec/fixtures/iocage_list')
       #provider_class.stub(:iocage).with(['list']) { fixture }
       allow(provider_class).to receive(:iocage).with(['list']) { fixture }
-      wanted = [{:jid=>"1", :uuid=>"b604d70f-220f-11e5-ad5f-0025905cf7cd", :boot=>"off", :state=>"up", :tag=>"mon1"}, {:jid=>"-", :uuid=>"fdfad85f-220c-11e5-ad5f-0025905cf7cd", :boot=>"off", :state=>"down", :tag=>"fbsd10.1"}]
+      wanted = [{:jid=>"-", :uuid=>"018e776d-4315-11e5-94bc-0025905cf7cc", :boot=>"off", :state=>"down", :tag=>"auth4"}, {:jid=>"-", :uuid=>"14b47568-448e-11e5-94bc-0025905cf7cc", :boot=>"off", :state=>"down", :tag=>"graphite2"}, {:jid=>"1", :uuid=>"19e2885e-448e-11e5-94bc-0025905cf7cc", :boot=>"on", :state=>"up", :tag=>"git2"}, {:jid=>"2", :uuid=>"64a7af2c-4909-11e5-9073-0025905cf7cc", :boot=>"on", :state=>"up", :tag=>"pm3"}, {:jid=>"-", :uuid=>"c3936d1d-46f5-11e5-9073-0025905cf7cc", :boot=>"off", :state=>"down", :tag=>"ns1"}, {:jid=>"333", :uuid=>"ca29dc76-46f6-11e5-9073-0025905cf7cc", :boot=>"on", :state=>"up", :tag=>"pdb2"}, {:jid=>"-", :uuid=>"e2f5f461-4314-11e5-94bc-0025905cf7cc", :boot=>"off", :state=>"down", :tag=>"mon1"}]
       expect(provider_class.jail_list).to eq(wanted)
     end
   end


### PR DESCRIPTION
Without this change, the provider attempts to parse the data from
'iocage list' even when non-iocage-managed jails are present.  Due to a
difference between the way iocage jails and non-iocage jails are
represented, the resutls are incorrect, and cause problems with jail
detection.

This work updates the fixtures to contain such an example (during a
poudriere build) and builds a regex to match only the iocage jails.
Currently we throw away the matches and only test that we actually have
the correct data.