### PR TITLE
Add user_data support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+ - Add user_data support for first boot shell
 
 ## 2016-04-25 2.0.9
 ### Summary

--- a/README.md
+++ b/README.md
@@ -21,16 +21,17 @@ specify the pool on each jail.
 
 ```Puppet
 jail { 'myjail1':
-  ensure   => present,
-  state    => 'up',
-  ip4_addr => 'em0|10.0.0.10/24',
-  ip6_addr => 'em0|fc00::10/64',
-  hostname => 'myjail1.example.com',
-  boot     => 'on'
+  ensure    => present,
+  state     => 'up',
+  ip4_addr  => 'em0|10.0.0.10/24',
+  ip6_addr  => 'em0|fc00::10/64',
+  hostname  => 'myjail1.example.com',
+  boot      => 'on',
+  user_data => template('mysite/user_data.sh.erb'),
 }
 ```
 
-Note the `ip4_addr` and the `ip6_addr` properties take an interface name and an IP address seperated by a pipe character.  This value is passed directly to `iocage(8)`.  You may wish to read the man page.
+Note the `ip4_addr` and the `ip6_addr` properties take an interface name and an IP address separated by a pipe character.  This value is passed directly to `iocage(7)`.  You may wish to read the man page.
 
 [iocage]: http://iocage.readthedocs.org/en/latest/
 

--- a/lib/puppet/provider/jail/iocage.rb
+++ b/lib/puppet/provider/jail/iocage.rb
@@ -1,3 +1,5 @@
+require 'tempfile'
+
 Puppet::Type.type(:jail).provide(:iocage) do
 
   desc "Manage jails using iocage(8)"
@@ -159,6 +161,15 @@ Puppet::Type.type(:jail).provide(:iocage) do
               end
             }
             iocage(['start', resource[:name]])
+            if resource[:user_data]
+              tmpfile = Tempfile.new('puppet-iocage')
+              tmpfile.write(resource[:user_data])
+              tmpfile.close
+              execute("/usr/local/sbin/iocage exec #{resource[:name]} /bin/sh",
+                { :stdinfile => tmpfile.path }
+              )
+              tmpfile.delete
+            end
           end
         end
       end

--- a/lib/puppet/type/jail.rb
+++ b/lib/puppet/type/jail.rb
@@ -17,6 +17,10 @@ Puppet::Type.newtype(:jail) do
     desc "The jail ID for running jails"
   end
 
+  newparam(:user_data) do
+    desc "Rendered content to pipe to a jailed shell upon creation"
+  end
+
   newproperty(:state) do
     desc "Either running or stopped"
     newvalues(:up, :down)


### PR DESCRIPTION
This work adds a new parameter to support passing in user_data content
upon first boot.  This is implemented in the form of creating a
temporary file passed to the execute() method in the Puppet utilities.
The file relies on the default mode of 0600 for the creation, and is
removed once executed.