### PR TITLE
Improve testing and drop legacy support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,13 @@ before_install:
   - gem update bundler
 rvm:
   - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.0
+  - 2.1
+  - 2.2
 script: bundle exec rake test
 env:
-  - PUPPET_VERSION="~> 3.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.0.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 4.1.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 4.2.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 4.3.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 4.4.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.5.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.6.1" STRICT_VARIABLES=yes

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,14 @@ source "https://rubygems.org"
 
 group :test do
   gem "rake"
-  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.0'
+  gem "puppet", ENV['PUPPET_VERSION'] || '~> 4.6.1'
   gem "rspec"
   gem "rspec-core"
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "rspec-puppet-facts"
+  gem 'json_pure', '<=2.0.1', :require => false if RUBY_VERSION =~ /^1\./
 end
 
 group :development do

--- a/spec/fixtures/iocage_jail_get_all
+++ b/spec/fixtures/iocage_jail_get_all
@@ -8,7 +8,7 @@ ip4_autoend:none
 ip4_autosubnet:none
 ip4_saddrsel:1
 ip4:new
-ip6_addr:ethernet0|2001:470:deed::100/64
+ip6_addr:ethernet0|2001:470:deed::100
 ip6_saddrsel:1
 ip6:new
 defaultrouter:none

--- a/spec/unit/puppet/provider/iocage_spec.rb
+++ b/spec/unit/puppet/provider/iocage_spec.rb
@@ -31,6 +31,8 @@ describe provider_class do
       results.should(include('boot' => 'on'))
       results.should(include('jail_zfs' => 'on'))
       results.should(include('jail_zfs_dataset' => 'media_in'))
+      results.should(include('ip4_addr' => 'ethernet0|10.0.0.10'))
+      results.should(include('ip6_addr' => 'ethernet0|2001:470:deed::100'))
     end
 
   end

--- a/spec/unit/puppet/type/jail_spec.rb
+++ b/spec/unit/puppet/type/jail_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'puppet/type/jail'
+
+type_class = Puppet::Type.type(:jail)
+
+describe type_class do
+
+  [:absent, :present].each do |v|
+    it "should support #{v} as a value to :ensure" do
+      j = type_class.new(:name => 'myjail', :ensure => v)
+      expect(j.should(:ensure)).to eq(v)
+    end
+  end
+
+  let :params do
+    [
+      :name,
+      :jid,
+      :user_data,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+      :state,
+      :boot,
+      :ip4_addr,
+      :ip6_addr,
+      :jail_zfs,
+      :jail_zfs_dataset,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+end


### PR DESCRIPTION
Here we add tests for existing functionality and drop support for older
Puppet versions.