### PR TITLE
add pkglist parameter to jail type

### DIFF
--- a/lib/puppet/provider/jail/iocage_legacy.rb
+++ b/lib/puppet/provider/jail/iocage_legacy.rb
@@ -158,14 +158,21 @@ Puppet::Type.type(:jail).provide(:iocage_legacy) do
         :jail_zfs_dataset
       ]
 
+      unless resource[:pkglist].empty?
+        pkgfile = Tempfile.new('puppet-iocage-pkg.list')
+        pkgfile.write(resource[:pkglist].join("\n"))
+        pkgfile.close
+        pkglist = "--pkglist=#{pkgfile.path}"
+      end
+
       case resource[:ensure]
       when :absent
         iocage(['stop', resource[:name]])
         iocage(['destroy', '-f', resource[:name]])
       when :present
-        iocage(['create', '-c', "tag=#{resource[:name]}"])
+        iocage(['create', '-c', pkglist, "tag=#{resource[:name]}"].compact)
       when :template
-        iocage(['create', '-c', "tag=#{resource[:name]}"])
+        iocage(['create', '-c', pkglist, "tag=#{resource[:name]}"].compact)
         set_property('template', 'yes')
       end
 

--- a/lib/puppet/type/jail.rb
+++ b/lib/puppet/type/jail.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:jail) do
     newvalues(:on, :off)
   end
 
+  newparam(:pkglist, array_matching: :all) do
+    desc 'A list of packages to be installed in this jail before startup'
+  end
+
   newproperty(:jail_zfs_dataset) do
     desc 'Set the jail_zfs_data set iocage parameter'
     validate do |value|

--- a/lib/puppet/type/jail.rb
+++ b/lib/puppet/type/jail.rb
@@ -50,15 +50,26 @@ Puppet::Type.newtype(:jail) do
     newvalues(:on, :off)
   end
 
-  newparam(:pkglist, array_matching: :all) do
-    desc 'A list of packages to be installed in this jail before startup'
-  end
-
   newproperty(:jail_zfs_dataset) do
     desc 'Set the jail_zfs_data set iocage parameter'
     validate do |value|
       unless value.is_a? String
         raise ArgumentError, 'jail_zfs_dataset requires string value'
+      end
+    end
+  end
+
+  newparam(:pkglist, array_matching: :all) do
+    desc 'A list of packages to be installed in this jail before startup'
+    def insync?(is)
+      Array(is).sort == Array(@shouldA).sort
+    end
+
+    newvalues(%r{^}) do
+      begin
+        provider.update
+      rescue => detail
+        raise Puppet::Error, "Could not update: #{detail}"
       end
     end
   end


### PR DESCRIPTION
This adds the array paremeter `pkglist` to jail.
This parameter is not discoverable thru `iocage get all <jail>`.
But, what happens when this parameter changes? Effectively, we'll have
to rebuild the jail.