### PR TITLE
Add new parameters for jail configuration

### DIFF
--- a/lib/puppet/provider/jail/iocage_legacy.rb
+++ b/lib/puppet/provider/jail/iocage_legacy.rb
@@ -59,6 +59,11 @@ Puppet::Type.type(:jail).provide(:iocage_legacy) do
         :ip4_addr,
         :ip6_addr,
         :hostname,
+        :pcpu,
+        :memoryuse,
+        :quota,
+        :release,
+        :rlimits,
         :jail_zfs,
         :jail_zfs_dataset
       ]
@@ -137,6 +142,26 @@ Puppet::Type.type(:jail).provide(:iocage_legacy) do
     @property_flush[:hostname] = value
   end
 
+  def pcpu=(value)
+    @property_flush[:pcpu] = value
+  end
+
+  def memoryuse=(value)
+    @property_flush[:memoryuse] = value
+  end
+
+  def quota=(value)
+    @property_flush[:quota] = value
+  end
+
+  def release=(value)
+    @property_flush[:release] = value
+  end
+
+  def rlimits=(value)
+    @property_flush[:rlimits] = value
+  end
+
   def jail_zfs=(value)
     @property_flush[:jail_zfs] = value
   end
@@ -154,6 +179,11 @@ Puppet::Type.type(:jail).provide(:iocage_legacy) do
         :ip4_addr,
         :ip6_addr,
         :hostname,
+        :pcpu,
+        :memoryuse,
+        :quota,
+        :release,
+        :rlimits,
         :jail_zfs,
         :jail_zfs_dataset
       ]

--- a/lib/puppet/type/jail.rb
+++ b/lib/puppet/type/jail.rb
@@ -45,6 +45,27 @@ Puppet::Type.newtype(:jail) do
     desc 'Hostname of the jail'
   end
 
+  newproperty(:pcpu) do
+    desc "Cap the CPU usage of a jail"
+  end
+
+  newproperty(:memoryuse) do
+    desc "Cap the RAM usage of a jail"
+  end
+
+  newproperty(:quota) do
+    desc "Set maximum disk usage for a jail"
+  end
+
+  newproperty(:release) do
+    desc "Set jail version"
+  end
+
+  newproperty(:rlimits) do
+    desc "Enable|Disable Limits"
+    newvalues(:on, :off)
+  end
+
   newproperty(:jail_zfs) do
     desc 'Enable the jail_zfs'
     newvalues(:on, :off)

--- a/lib/puppet/type/jail.rb
+++ b/lib/puppet/type/jail.rb
@@ -46,23 +46,23 @@ Puppet::Type.newtype(:jail) do
   end
 
   newproperty(:pcpu) do
-    desc "Cap the CPU usage of a jail"
+    desc 'Cap the CPU usage of a jail'
   end
 
   newproperty(:memoryuse) do
-    desc "Cap the RAM usage of a jail"
+    desc 'Cap the RAM usage of a jail'
   end
 
   newproperty(:quota) do
-    desc "Set maximum disk usage for a jail"
+    desc 'Set maximum disk usage for a jail'
   end
 
   newproperty(:release) do
-    desc "Set jail version"
+    desc 'Set jail version'
   end
 
   newproperty(:rlimits) do
-    desc "Enable|Disable Limits"
+    desc 'Enable|Disable Limits'
     newvalues(:on, :off)
   end
 


### PR DESCRIPTION
This pull request, if I understand the ruby correctly, should add support for:
- rlimits (on|off)
- quota (Disk Max for jail)
- memoryuse (RAM cap)
- pcpu (CPU usage cap)
- release (FreeBSD release to deploy) 