### PR TITLE
Add iocell provider, and jailmanager selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,20 @@ This module expects to be the only jail manager on a given system.  Each system 
 ```Puppet
 include jail::setup
 ```
+This module supports `iocage` legacy, `py-iocage`, and `iocell`.
+To choose between them, pick one of the following:
 
-This simply installs 'iocage' and removes '/etc/jail.conf'.
+```Puppet
+include jail::iocage
+```
+```Puppet
+include jail::iocell
+```
+```Puppet
+include jail::py-iocage
+```
+
+This simply installs 'iocage', `py-iocage`, or `iocell`, and removes '/etc/jail.conf'.
 
 This allows the type to use the correct jail without having to
 specify the pool on each jail.
@@ -27,6 +39,11 @@ jail { 'myjail1':
   ip6_addr  => 'em0|fc00::10/64',
   hostname  => 'myjail1.example.com',
   boot      => 'on',
+  pcpu      => '20'
+  memoryuse => '4G',
+  quota     => '15G',
+  release   => '11.1-RELEASE'
+  rlimits   => 'on',
   user_data => template('mysite/user_data.sh.erb'),
 }
 ```

--- a/lib/puppet/provider/jail/iocell.rb
+++ b/lib/puppet/provider/jail/iocell.rb
@@ -1,0 +1,247 @@
+require 'tempfile'
+
+Puppet::Type.type(:jail).provide(:iocell) do
+  desc 'Manage jails using iocell(8)'
+  confine    kernel: :freebsd
+  defaultfor kernel: :freebsd
+
+  commands iocell: '/usr/local/sbin/iocell'
+
+  mk_resource_methods
+
+  def self.jail_list(*args)
+    output = iocell(['list', args].flatten).split("\n")
+    fields = output.shift.split.map { |i| i.downcase.to_sym }
+
+    data = []
+
+    output.each do |j|
+      jail_data = {}
+      values = j.split
+
+      iocell_jail_list_regex = %r{^(-|[0-9]+)\s+([[:xdigit:]]{8}-([[:xdigit:]]{4}-){3})[[:xdigit:]]{12}\s+(on|off)\s+(up|down)\s+.+$}
+      next if iocell_jail_list_regex.match(j).nil?
+
+      values.each_index do |i|
+        jail_data[fields[i]] = values[i]
+      end
+      data << jail_data
+    end
+
+    data
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if (resource = resources[prov.name])
+        resource.provider = prov
+      end
+    end
+  end
+
+  def self.instances
+    [jail_list, jail_list('-t')].each.map do |j|
+      all_properties = get_jail_properties(j[:tag])
+
+      jensure = all_properties['template'] == 'yes' ? :template : :present
+
+      jail_properties = {
+        provider: :iocell,
+        ensure: jensure,
+        name: j[:tag],
+        state: j[:state],
+        boot: j[:boot]
+      }
+
+      jail_properties[:jid] = j[:jid] if j[:jid] != '-'
+
+      extra_properties = [
+        :ip4_addr,
+        :ip6_addr,
+        :hostname,
+        :pcpu,
+        :memoryuse,
+        :quota,
+        :release,
+        :rlimits,
+        :jail_zfs,
+        :jail_zfs_dataset
+      ]
+
+      extra_properties.each do |p|
+        jail_properties[p] = all_properties[p.to_s]
+      end
+
+      debug jail_properties
+
+      new(jail_properties)
+    end
+  end
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  def self.get_jail_properties(jailname)
+    data = {}
+    output = iocell(['get', 'all', jailname])
+    output.lines.each do |l|
+      key, value = l.split(':', 2)
+      data[key] = value.chomp
+    end
+    data.reject! { |k, v| k.nil? || v.nil? }
+
+    debug data
+
+    data
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present || @property_hash[:ensure] == :template
+  end
+
+  def running?
+    @property_hash[:state] == :up
+  end
+
+  def create
+    @property_flush[:ensure] = resource[:ensure]
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def restart
+    iocell(['stop', resource[:name]])
+    iocell(['start', resource[:name]])
+  end
+
+  def set_property(property, value)
+    iocell(['set', "#{property}=#{value}", resource[:name]])
+  end
+
+  def state=(value)
+    @property_flush[:state] = value
+  end
+
+  def boot=(value)
+    @property_flush[:boot] = value
+  end
+
+  def ip4_addr=(value)
+    @property_flush[:ip4_addr] = value
+  end
+
+  def ip6_addr=(value)
+    @property_flush[:ip6_addr] = value
+  end
+
+  def hostname=(value)
+    @property_flush[:hostname] = value
+  end
+
+  def pcpu=(value)
+    @property_flush[:pcpu] = value
+  end
+
+  def memoryuse=(value)
+    @property_flush[:memoryuse] = value
+  end
+
+  def quota=(value)
+    @property_flush[:quota] = value
+  end
+
+  def release=(value)
+    @property_flush[:release] = value
+  end
+
+  def rlimits=(value)
+    @property_flush[:rlimits] = value
+  end
+
+  def jail_zfs=(value)
+    @property_flush[:jail_zfs] = value
+  end
+
+  def jail_zfs_dataset=(value)
+    @property_flush[:jail_zfs_dataset] = value
+  end
+
+  def flush
+    if @property_flush
+      Puppet.debug "JailIocell(#flush): #{@property_flush}"
+
+      pre_start_properties = [
+        :boot,
+        :ip4_addr,
+        :ip6_addr,
+        :hostname,
+        :pcpu,
+        :memoryuse,
+        :quota,
+        :release,
+        :rlimits,
+        :jail_zfs,
+        :jail_zfs_dataset
+      ]
+
+      unless resource[:pkglist].empty?
+        pkgfile = Tempfile.new('puppet-iocell-pkg.list')
+        pkgfile.write(resource[:pkglist].join("\n"))
+        pkgfile.close
+        pkglist = "--pkglist=#{pkgfile.path}"
+      end
+
+      case resource[:ensure]
+      when :absent
+        iocell(['stop', resource[:name]])
+        iocell(['destroy', '-f', resource[:name]])
+      when :present
+        iocell(['create', '-c', pkglist, "tag=#{resource[:name]}"].compact)
+      when :template
+        iocell(['create', '-c', pkglist, "tag=#{resource[:name]}"].compact)
+        set_property('template', 'yes')
+      end
+
+      if resource[:state] == :up && resource[:ensure] == :present
+        pre_start_properties.each do |p|
+          set_property(p.to_s, resource[p]) if resource[p]
+        end
+        iocell(['start', resource[:name]])
+        if resource[:user_data]
+          tmpfile = Tempfile.new('puppet-iocell')
+          tmpfile.write(resource[:user_data])
+          tmpfile.close
+          execute("/usr/local/sbin/iocell exec #{resource[:name]} /bin/sh",
+                  stdinfile: tmpfile.path)
+          tmpfile.delete
+        end
+      end
+
+      need_restart = false
+      pre_start_properties.each do |p|
+        if @property_flush[p]
+          need_restart = true
+          set_property(p.to_s, @property_flush[p])
+        end
+      end
+
+      if @property_flush[:state]
+        case resource[:state]
+        when :up
+          need_restart = false
+          iocell(['start', resource[:name]])
+        when :down
+          need_restart = false
+          iocell(['stop', resource[:name]])
+        end
+      end
+
+      restart if need_restart
+    end
+    @property_hash = resource.to_hash
+  end
+end

--- a/manifests/iocage_legacy.pp
+++ b/manifests/iocage_legacy.pp
@@ -1,0 +1,7 @@
+# Class: jail::iocage_legacy
+#
+#
+class jail::iocage_legacy {
+  $jailmanager  = 'iocage'
+  $jailservice  = 'iocage'
+}

--- a/manifests/iocell.pp
+++ b/manifests/iocell.pp
@@ -1,0 +1,7 @@
+# Class: jail::iocell
+#
+#
+class jail::iocell {
+  $jailmanager  = 'iocell'
+  $jailservice  = 'iocell'
+}

--- a/manifests/py-iocage.pp
+++ b/manifests/py-iocage.pp
@@ -1,0 +1,7 @@
+# Class: jail::py-iocage
+#
+#
+class jail::py-iocage {
+  $jailmanager  = 'iocage'
+  $jailservice  = 'iocage'
+}

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -5,18 +5,17 @@
 #
 class jail::setup () {
 
-  package { 'iocage':
-    ensure => installed,
+  package { $jailmanager:
+    ensure  => latest,
+    require => File['/etc/jail.conf'],
   }
 
-  service { 'iocage':
-    enable => true,
+  service { $jailservice:
+    enable  => true,
+    require => [File['/etc/jail.conf'], Package[$jailmanager]],
   }
 
   file { '/etc/jail.conf':
     ensure => absent,
   }
-
-  File['/etc/jail.conf'] ~> Service['iocage']
-  Package['iocage'] ~> Service['iocage']
 }


### PR DESCRIPTION
This PR will add the `iocell` provider, and an option to choose your preferred jail manager, between `iocage` legacy, `py-iocage`, and `iocell`.

I'm sure there's a better way to do it with a defined type, but the variable include seems to work just as well.