### PR TITLE
Set the property only if required

### DIFF
--- a/lib/puppet/provider/jail/pyiocage.rb
+++ b/lib/puppet/provider/jail/pyiocage.rb
@@ -119,6 +119,7 @@ Puppet::Type.type(:jail).provide(:pyiocage) do
     end
     data.reject! { |k, v| k.nil? || Fields.include?(k.to_sym) || v.nil? || v == jailname }
 
+    debug 'Data for get_jail_properties'
     debug data
 
     Set.new(data).freeze
@@ -288,7 +289,12 @@ Puppet::Type.type(:jail).provide(:pyiocage) do
 
       if @property_flush[:properties]
         # none of these need a restart
-        @property_flush[:properties].each { |p, v| set_property(p.to_s, v) }
+        keys_to_set = @property_flush[:properties].reject do |_p, _v|
+          @property_hash.keys.include?
+        end
+        keys_to_set.each do |x|
+          set_property(x.to_s, @property_flush[x]) if @property_hash[x] != @property_flush[x]
+        end
       end
 
       if @property_flush[:state]


### PR DESCRIPTION
Without this change, all properties are set each application.  In my
environment, this appears to be due to a recent change where devfs_rulesets
don't appear to match the defaults, and are detected as a change by puppet,
which then are changed back to the correct values, though some of the values may
already be set to the desired value.  Here we ensure that the values that match
the current value are not attempted to be set.  This avoids unnecessary calls to
the iocage utility, and also skips attempts to modify settings that are not
settable while a jail is running.